### PR TITLE
✨ Task-27: 로그인 유저 라우팅

### DIFF
--- a/src/contexts/Authorization/Authorization.jsx
+++ b/src/contexts/Authorization/Authorization.jsx
@@ -1,0 +1,34 @@
+import { createContext, useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+
+import { SIGN_IN_PAGE, SIGN_UP_PAGE } from '@constants';
+import { auth } from '@utils';
+
+export const AuthorizationContext = createContext(null);
+
+export const AuthorizationProvider = ({ children }) => {
+  const { pathname, replace } = useRouter();
+  const [isLoading, setIsLoading] = useState(true);
+  const [isAuthorized, setIsAuthorized] = useState(false);
+
+  useEffect(() => {
+    const changeAuthorization = (user) => {
+      setIsAuthorized(!!user ? true : false);
+      setIsLoading(false);
+    };
+
+    const unSubscribe = auth.onAuthStateChanged(changeAuthorization);
+    return () => unSubscribe();
+  }, []);
+
+  useEffect(() => {
+    if (isLoading) return;
+    if (isAuthorized || unAuthenticatedRouteList.includes(pathname)) return;
+
+    replace(SIGN_IN_PAGE);
+  }, [isLoading, isAuthorized, pathname, replace]);
+
+  return <AuthorizationContext.Provider value={{}}>{children}</AuthorizationContext.Provider>;
+};
+
+const unAuthenticatedRouteList = [SIGN_UP_PAGE, SIGN_IN_PAGE];

--- a/src/contexts/Authorization/index.js
+++ b/src/contexts/Authorization/index.js
@@ -1,2 +1,1 @@
 export * from './Authorization';
-export * from './KakaoMap';

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -1,16 +1,18 @@
 import { Global } from '@emotion/react';
 
 import { Layout } from '@components';
-import { KakaoMapProvider } from '@contexts';
+import { AuthorizationProvider, KakaoMapProvider } from '@contexts';
 import { globalStyle } from '@styles';
 
 const App = ({ Component, pageProps }) => {
   return (
     <KakaoMapProvider>
-      <Global styles={globalStyle} />
-      <Layout>
-        <Component {...pageProps} />
-      </Layout>
+      <AuthorizationProvider>
+        <Global styles={globalStyle} />
+        <Layout>
+          <Component {...pageProps} />
+        </Layout>
+      </AuthorizationProvider>
     </KakaoMapProvider>
   );
 };


### PR DESCRIPTION
#51 

## 로그인한 유저가 유효한 유저인가?
firebase auth에는 만료기한 토큰이 존재한다. 
만료가 된다면 해당 토큰은 무의미한 토큰이 된다.
현재 서비스에서는 user의 uuid만 필요하며 리프레시 로직을 따로 작성하기가 어려운 상황이다.
그래서 적어도 프론트에서 유효한 유저인지 확인하는 방법을 고민하게 됐다.

### onAuthStateChanged
auth객체 내부나 auth 메서드에 존재하는 함수이다. 공식문서에 따르면 auth 상태 변경을 observer하는 함수이다.
상태변경에는 로그인, 로그아웃, 토큰 리프레시가 속한다.
현재 가장 필요했던 부분이 토큰리프레시도 observe 가능하므로 사용하기로 했다.

### unSubscribe
useEffect로 감싸서 한번만 호출하기 위해 사용하기로 했다.
onAuthStateChanged는 등록하기만 했지 해제하는 로직이 없어 공식문서를 찾아보니 return값으로  Unsubscribe 함수를 반환하는 것을 알게 됐다.
그래서 clean up 함수에 등록하여 Unsubscribe 처리했다.

## 인증 로직
firebase에서는 auth의 토큰의 만료시간이 되면 알아서 요청하여 수정해준다. 그렇기에 클라이언트에서는 별도의 만료시간 확인, 업데이트 로직이 필요하지 않는 상황이라 유저가 존재하는지만 확인하고 옳바르게 라우팅만 해주면 된다. (firebase 보기보다 편한듯..)
로직은 아래와 같다.
1. 로딩중인지 확인 -> changeAuthorization 함수가 비동기 함수 이므로 해당 함수가 종료되는 시점을 알려주어야한다.
2. 유저가 존재하는지 확인
  a. 존재한다면 현재 상태유지
  b. 아니라면 로그인페이지로 이동