### PR TITLE
✨ Task-28: 유저에 따라 마커 저장, 불러오기 수정

### DIFF
--- a/src/contexts/Authorization/Authorization.jsx
+++ b/src/contexts/Authorization/Authorization.jsx
@@ -28,7 +28,7 @@ export const AuthorizationProvider = ({ children }) => {
     replace(SIGN_IN_PAGE);
   }, [isLoading, isAuthorized, pathname, replace]);
 
-  return <AuthorizationContext.Provider value={{}}>{children}</AuthorizationContext.Provider>;
+  return <AuthorizationContext.Provider value={{ isAuthorized }}>{children}</AuthorizationContext.Provider>;
 };
 
 const unAuthenticatedRouteList = [SIGN_UP_PAGE, SIGN_IN_PAGE];

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -1,1 +1,2 @@
 export * from './useMarker';
+export * from './useUserInfo';

--- a/src/hooks/useUserInfo.js
+++ b/src/hooks/useUserInfo.js
@@ -1,0 +1,17 @@
+import { useContext, useEffect, useState } from 'react';
+
+import { AuthorizationContext } from '@contexts';
+import { auth } from '@utils';
+
+export const useUserInfo = () => {
+  const { isAuthorized } = useContext(AuthorizationContext);
+  const [userInfo, setUserInfo] = useState(null);
+
+  useEffect(() => {
+    if (!isAuthorized || !auth.currentUser) return;
+
+    setUserInfo({ id: auth.currentUser.uid, email: auth.currentUser.email });
+  }, [isAuthorized]);
+
+  return { userInfo };
+};

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -2,22 +2,27 @@ import React, { useCallback, useEffect, useState } from 'react';
 
 import { Information, Map } from '@components';
 import { createMarkerAPI, deleteMarkerAPI, getMarkerListAPI, updateMarkerAPI } from '@services';
+import { useUserInfo } from '@hooks';
 
 const Home = () => {
+  const { userInfo } = useUserInfo();
+
   const [isEditable, setIsEditable] = useState(false);
   const [current, setCurrent] = useState(null);
   const [markerList, setMarkerList] = useState([]);
 
   // API 관련 함수
   const fetchMarkerList = useCallback(async () => {
-    const data = await getMarkerListAPI();
+    if (!userInfo) return;
+
+    const data = await getMarkerListAPI(userInfo.id);
     setMarkerList(data);
-  }, []);
+  }, [userInfo]);
 
   const handleCreateMarker = useCallback(
     async (option) => {
       try {
-        const { id } = await createMarkerAPI(option);
+        const { id } = await createMarkerAPI({ ...option, userId: userInfo.id });
         await fetchMarkerList();
         setCurrent((value) => ({ ...value, id }));
       } catch {
@@ -25,7 +30,7 @@ const Home = () => {
         setIsEditable(false);
       }
     },
-    [fetchMarkerList]
+    [userInfo, fetchMarkerList]
   );
 
   const handleUpdateMarker = useCallback(

--- a/src/services/marker.js
+++ b/src/services/marker.js
@@ -1,4 +1,4 @@
-import { addDoc, collection, deleteDoc, doc, getDocs, updateDoc } from 'firebase/firestore';
+import { addDoc, collection, deleteDoc, doc, getDocs, query, updateDoc, where } from 'firebase/firestore';
 
 import { db } from '@utils';
 
@@ -14,8 +14,8 @@ export const updateMarkerAPI = async (id, option) => {
   await updateDoc(doc(markerReference, id), option);
 };
 
-export const getMarkerListAPI = async () => {
-  const { docs } = await getDocs(markerReference);
+export const getMarkerListAPI = async (userId) => {
+  const { docs } = await getDocs(query(markerReference, where('userId', '==', userId)));
 
   return docs.map((doc) => ({ id: doc.id, ...doc.data() }));
 };


### PR DESCRIPTION
#53 

## auth.currentUser
auth.currentUser가 늦게 업데이트되는 상황이라 null값이어서 현재 유저의 정보를 받을 수 없는 상황이었다.
Authorization Context에서 loading과 onAuthStateChanged의 로직을 거치게 되면 auth.currentUser를 제대로 확인할 수 있게 됐다.
그래서 userInfo hook에서 Authorization Context의 결과인 isAuthorized가 필요하여 context 값으로 추가했다.

## create, read userId 추가
기존 marker의 값에 userId 속성을 추가하여 사용자에 따라 자신의 마커를 보여주도록 구현했다.
update, delete에는 추가하지 않은 이유는 marker id로 가능하기 때문에 그러지 않았다.